### PR TITLE
Finished testing the conversation aspect of metamuse. Next to return …

### DIFF
--- a/libs/utils/src/utils.constants.ts
+++ b/libs/utils/src/utils.constants.ts
@@ -8,6 +8,7 @@ export const JWT_VERIFYING_KEY = process.env.JWT_VERIFYING_KEY as string;
 export const JWT_ACCESS_TOKEN_EXPIRATION = parseInt(
   process.env.JWT_ACCESS_TOKEN_EXPIRATION as string,
 );
+export const JWT_SIGNED_TOKEN_EXPIRY = process.env.JWT_SIGNED_TOKEN_EXPIRY as string;
 export const JWT_REFRESH_TOKEN_EXPIRATION = parseInt(
   process.env.JWT_REFRESH_TOKEN_EXPIRATION as string,
 );

--- a/src/conversation/conversation.module.ts
+++ b/src/conversation/conversation.module.ts
@@ -4,11 +4,13 @@ import { ConversationService, MessageService } from './conversation.service';
 import { ConversationController } from './conversation.controller';
 import { Conversation, Message, ConversationSchema, MessageSchema } from './conversation.schema'
 import { UsersModule } from 'src/users/users.module';
+import { AuthModule } from 'src/auth/auth.module';
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Conversation.name, schema: ConversationSchema }]),
     MongooseModule.forFeature([{ name: Message.name, schema: MessageSchema }]),
-    UsersModule
+    UsersModule,
+    AuthModule,
   ],
   controllers: [ConversationController],
   providers: [ConversationService, MessageService],

--- a/src/conversation/conversation.permission.ts
+++ b/src/conversation/conversation.permission.ts
@@ -1,22 +1,28 @@
 import { BasePermission } from '@app/utils/utils.permission';
+import { Types } from 'mongoose';
 
 export class IsConversationCreator extends BasePermission {
   hasObjectPermission(request: any, resource: any, action: string): boolean {
-    return request.user && resource && resource.creator._id === request.user._id;
+    return request.user && resource && resource.creator._id.equals( request.user._id);
   }
 }
 
 export class IsConversationAdmin extends BasePermission {
   hasObjectPermission(request: any, resource: any, action: string): boolean {
     return (
-      request.user && resource && resource.admins.includes(request.user._id)
+      request.user &&
+      resource &&
+      resource.admins.some((admin: Types.ObjectId) => admin.equals(request.user._id))
     );
   }
 }
 export class IsConversationMember extends BasePermission {
   hasObjectPermission(request: any, resource: any, action: string): boolean {
+    console.log("Handling", resource.members, request.user._id)
     return (
-      request.user && resource && resource.members.includes(request.user._id)
+      request.user &&
+      resource &&
+      resource.members.some((member: Types.ObjectId) => member.equals(request.user._id))
     );
   }
 }

--- a/todo.MD
+++ b/todo.MD
@@ -1,0 +1,3 @@
+* [ ] Add roles and scopes to the users
+* [ ] Add integrations with notification systems and emails
+* [ ] Test


### PR DESCRIPTION
This pull request introduces several changes to the authentication and conversation modules, including the addition of token-based link creation and verification, updates to conversation member and admin management, and various code improvements.

### Authentication Enhancements:
* Added `JWT_SIGNED_TOKEN_EXPIRY` and `JWT_VERIFYING_KEY` constants to `utils.constants.ts` for token expiry and verification.
* Introduced `createLinkToken` and `verifyLinkToken` methods in `AuthService` to handle token-based link creation and verification.

### Conversation Module Updates:
* Added `AuthService` to `ConversationController` and integrated link-based member addition with `createLinkToken` and `verifyLinkToken` methods. [[1]](diffhunk://#diff-32f82a504a4da9b898b85591364b59777f903038dfc0ff97266595192974348fR49) [[2]](diffhunk://#diff-32f82a504a4da9b898b85591364b59777f903038dfc0ff97266595192974348fL444-R492)
* Ensured conversation members and admins are populated with relevant fields (`_id`, `email`, `firstName`, `lastName`) after various operations. [[1]](diffhunk://#diff-32f82a504a4da9b898b85591364b59777f903038dfc0ff97266595192974348fL126-R132) [[2]](diffhunk://#diff-32f82a504a4da9b898b85591364b59777f903038dfc0ff97266595192974348fR317-R318)

### Permission and Validation Improvements:
* Updated permission classes in `conversation.permission.ts` to use `Types.ObjectId.equals` for comparison instead of direct equality checks.
* Added validation to ensure users are members before being assigned as admins in `ConversationService`.

### Miscellaneous:
* Updated `todo.MD` with new tasks for roles, scopes, and integrations.