### PR TITLE
Added sui environmental variables

### DIFF
--- a/libs/utils/src/utils.constants.ts
+++ b/libs/utils/src/utils.constants.ts
@@ -28,3 +28,9 @@ export const PORT = parseInt(process.env.NEST_PORT as string);
 
 // Conversation
 export const CONVERSATION_MAX_MEMBERS = 200;
+
+
+// SUI
+export const SUI_RPC_URL = process.env.SUI_RPC_URL as string;
+export const SUI_PRIVATE_KEY = process.env.SUI_PRIVATE_KEY as string;
+export const SUI_CONTRACT_ADDRESS = process.env.SUI_CONTRACT_ADDRESS as string;

--- a/src/sui/sui.service.ts
+++ b/src/sui/sui.service.ts
@@ -8,6 +8,7 @@ import { SuiClient, SuiHTTPTransport } from '@mysten/sui/client';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction } from '@mysten/sui/transactions';
 import { fromBase64 } from '@mysten/sui/utils';
+import { SUI_CONTRACT_ADDRESS, SUI_PRIVATE_KEY, SUI_RPC_URL } from '@app/utils';
 
 @Injectable()
 export class SuiService {
@@ -16,14 +17,14 @@ export class SuiService {
   private contractAddress: string;
 
   constructor() {
-    const rpcUrl = process.env.SUI_RPC_URL;
+    const rpcUrl = SUI_RPC_URL;
     this.client = new SuiClient({
       transport: new SuiHTTPTransport({
-        url: rpcUrl || 'https://fullnode.mainnet.sui.io:443',
+        url: rpcUrl,
       }),
     });
 
-    const privatekeyBase64 = process.env.SUI_PRIVATE_KEY;
+    const privatekeyBase64 = SUI_PRIVATE_KEY;
     if (!privatekeyBase64) {
       console.warn(
         'Warning: SUI_PRIVATE_KEY is not defined in environment variables',
@@ -34,7 +35,7 @@ export class SuiService {
       this.keypair = Ed25519Keypair.fromSecretKey(privatekeyBytes);
     }
 
-    this.contractAddress = process.env.SUI_CONTRACT_ADDRESS || '0x0';
+    this.contractAddress = SUI_CONTRACT_ADDRESS;
   }
 
   /**

--- a/src/users/users.schema.ts
+++ b/src/users/users.schema.ts
@@ -21,6 +21,9 @@ export class User {
 
     @Prop({ default: "unverified"}) // unverified, active, banned, deactivated
     status: string;
+
+    // @Prop({ type: [String], default: ["user"]}) // general, admin, artist
+    // roles: string[];
 }
 export const UserSchema =
     SchemaFactory.createForClass(User);


### PR DESCRIPTION
This pull request includes several changes to the SUI integration and minor adjustments to the user schema. The most important changes involve the centralization of SUI configuration variables and the removal of commented-out code in the user schema.

Centralization of SUI configuration variables:

* [`libs/utils/src/utils.constants.ts`](diffhunk://#diff-d65fc74c48aedd0b1f893a69ba81067a1cd2e86877a5b0f07348b970351a9e70R31-R36): Added constants for `SUI_RPC_URL`, `SUI_PRIVATE_KEY`, and `SUI_CONTRACT_ADDRESS` to centralize SUI configuration variables.
* [`src/sui/sui.service.ts`](diffhunk://#diff-028f8f10d878aa52ddd5622fa574c6ca10abeef3842407ce8bfe10342303d30cR11): Updated imports to include the new SUI configuration constants and replaced direct environment variable access with these constants. [[1]](diffhunk://#diff-028f8f10d878aa52ddd5622fa574c6ca10abeef3842407ce8bfe10342303d30cR11) [[2]](diffhunk://#diff-028f8f10d878aa52ddd5622fa574c6ca10abeef3842407ce8bfe10342303d30cL19-R27) [[3]](diffhunk://#diff-028f8f10d878aa52ddd5622fa574c6ca10abeef3842407ce8bfe10342303d30cL37-R38)

Minor adjustments:

* [`src/users/users.schema.ts`](diffhunk://#diff-c11e35d31b911ec15716725440a6052e0ae7b4ce88cd629a95883c8c1113076dR24-R26): Removed commented-out code for the `roles` property in the `User` schema.